### PR TITLE
fix(tests): unblock Windows/Node22 CI by rewriting fixture transcript_path

### DIFF
--- a/tests/hooks/_helpers.ts
+++ b/tests/hooks/_helpers.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import os from "node:os";
 import path from "node:path";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,6 +78,22 @@ export function runHook(
       // fixture JSON's `cwd` (e.g., "/tmp/curdx-fixture-spec") is irrelevant
       // on Windows; we substitute the runtime path here.
       parsed.cwd = options.cwd;
+
+      // Bug 3 fix: same treatment for `transcript_path`. Static fixtures
+      // (e.g., all-complete.json) hardcode `/tmp/curdx-fixture-transcripts/...`,
+      // which doesn't reliably resolve on Windows. If the field starts with
+      // `/tmp/`, replace the prefix with the platform tmpdir so the hook reads
+      // the file the test's beforeEach actually provisions there.
+      if (
+        typeof parsed.transcript_path === "string" &&
+        parsed.transcript_path.startsWith("/tmp/")
+      ) {
+        parsed.transcript_path = path.join(
+          os.tmpdir(),
+          parsed.transcript_path.slice("/tmp/".length),
+        );
+      }
+
       stdin = JSON.stringify(parsed);
     }
   } catch {

--- a/tests/hooks/stop-watcher.test.ts
+++ b/tests/hooks/stop-watcher.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { spawnSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { runHook } from "./_helpers.js";
@@ -9,6 +10,11 @@ import {
   createLegacyState,
   type FixtureSpec,
 } from "./_fixture-setup.js";
+
+// Cross-platform fixture transcript path. Hardcoded `/tmp/` fails on Windows
+// (CI Node22 leg) — see commit history for the original POC-gate test failure.
+const FIXTURE_TRANSCRIPT_DIR = path.join(os.tmpdir(), "curdx-fixture-transcripts");
+const FIXTURE_TRANSCRIPT_FILE = path.join(FIXTURE_TRANSCRIPT_DIR, "complete.txt");
 
 // ---------------------------------------------------------------------------
 // POC-gate (Task 1.8) helpers — local to this test file.
@@ -71,13 +77,13 @@ describe("stop-watcher (Stop hook)", () => {
       "{ this is not json",
     );
     // POC-gate fixtures (a)+(b) reference all-complete.json, whose
-    // transcript_path points at /tmp/curdx-fixture-transcripts/complete.txt.
+    // transcript_path points at FIXTURE_TRANSCRIPT_FILE (platform tmpdir).
     // byte-equal.test.ts beforeAll provisions this file, but if that suite
     // hasn't run yet (test isolation / fork ordering) we provision it here
     // defensively so these cases stay self-contained.
-    mkdirSync("/tmp/curdx-fixture-transcripts", { recursive: true });
+    mkdirSync(FIXTURE_TRANSCRIPT_DIR, { recursive: true });
     writeFileSync(
-      "/tmp/curdx-fixture-transcripts/complete.txt",
+      FIXTURE_TRANSCRIPT_FILE,
       "line one\nline two\nline three\nALL_TASKS_COMPLETE\n",
     );
   });
@@ -199,7 +205,7 @@ describe("stop-watcher (Stop hook)", () => {
   // The gate fires inside `handleCompletion()` (stop-watcher.ts ~L630) which
   // only runs when ALL_TASKS_COMPLETE is detected in the transcript. We use
   // the existing `all-complete.json` fixture (transcript_path points at
-  // /tmp/curdx-fixture-transcripts/complete.txt which contains the marker —
+  // FIXTURE_TRANSCRIPT_FILE under the platform tmpdir — contains the marker;
   // provisioned by byte-equal.test.ts beforeAll, but that helper writes it
   // unconditionally so it's already on disk by the time these tests run on
   // any machine that has run the suite once; we re-provision defensively in
@@ -416,7 +422,7 @@ describe("stop-watcher (Stop hook)", () => {
       const stdin = JSON.stringify({
         hookEvent: "Stop",
         cwd: reentrantSpec.cwd,
-        transcript_path: "/tmp/curdx-fixture-transcripts/complete.txt",
+        transcript_path: FIXTURE_TRANSCRIPT_FILE,
         stop_hook_active: true,
       });
       const result = spawnSync("node", [STOP_WATCHER_BUNDLE], {
@@ -529,7 +535,7 @@ describe("stop-watcher (Stop hook)", () => {
       const reentrantStdin = JSON.stringify({
         hookEvent: "Stop",
         cwd: orderingSpec.cwd,
-        transcript_path: "/tmp/curdx-fixture-transcripts/complete.txt",
+        transcript_path: FIXTURE_TRANSCRIPT_FILE,
         stop_hook_active: true,
       });
       const reentrantResult = spawnSync("node", [STOP_WATCHER_BUNDLE], {


### PR DESCRIPTION
## Summary

- Windows/Node22 CI has been red since OB-3 merge — 5/13 stop-watcher POC-gate tests fail with `expected '{\"decision\":\"block\",\"reason\":\"Continu…' to be ''`
- Root cause: `runHook` helper (`tests/hooks/_helpers.ts`) was finished half-way during v7.0.0-beta.1's "Bug 2 fix" — it rewrites the fixture's `cwd` field to the runtime tmpdir, but **forgot the same treatment for `transcript_path`**. Static fixtures like `all-complete.json` hardcode `/tmp/curdx-fixture-transcripts/complete.txt`, which doesn't reliably resolve on Windows, so `tailContainsCompletionMarker()` doesn't find `ALL_TASKS_COMPLETE` → handleCompletion never runs → fall-through to continuation block.
- Fix is two surgical edits:
  1. `_helpers.ts`: extend the existing cwd-rewrite block to also rewrite `transcript_path` when it starts with `/tmp/` (replace prefix with `os.tmpdir()`).
  2. `stop-watcher.test.ts`: replace 6 hardcoded `/tmp/` occurrences with `os.tmpdir()`-based constants so `beforeEach` provisions the transcript at the same path runHook now rewrites fixtures to.
- No fixture JSON files needed editing — change is fully behind the runHook helper layer.

## Verification

- macOS local: `npm run test:hooks` → 117/117 ✅ (was already passing)
- Windows: should now find the transcript at `<os.tmpdir()>/curdx-fixture-transcripts/complete.txt`
- typecheck clean

## Test plan

- [ ] CI matrix all 4 legs green (ubuntu-20, ubuntu-22, macos-22, windows-22)
- [ ] No regression in non-stop-watcher hook tests (the runHook helper change is backward-compatible — only affects fixtures whose transcript_path starts with `/tmp/`)
- [ ] `gh run watch` until terminal state

🤖 Generated with [Claude Code](https://claude.com/claude-code)